### PR TITLE
fix(ci): Add .firebaserc to repository

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,0 +1,13 @@
+{
+  "projects": {},
+  "targets": {
+    "apati-paseo-perro-pre": {
+      "hosting": {
+        "apati-paseo-perro": [
+          "apati-paseo-perro-pre"
+        ]
+      }
+    }
+  },
+  "etags": {}
+}


### PR DESCRIPTION
This PR adds the .firebaserc file, which is essential for the Firebase CLI to identify the correct hosting target during deployment. This should resolve the 'target not configured' error.