### PR TITLE
fix(ci): Use correct secret for Android deployment

### DIFF
--- a/.github/workflows/deploy-android.yml
+++ b/.github/workflows/deploy-android.yml
@@ -33,6 +33,6 @@ jobs:
         uses: wzieba/Firebase-Distribution-Github-Action@v1
         with:
           appId: '${{ secrets.FIREBASE_ANDROID_APP_ID }}'
-          serviceCredentialsFile: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_APATI_PASEO_PERRO_PRE }}'
+          serviceCredentialsFileContent: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_APATI_PASEO_PERRO_PRE }}'
           groups: 'testers-preproduccion'
           file: build/app/outputs/flutter-apk/app-release.apk


### PR DESCRIPTION
This PR fixes the authentication issue in the Android deployment workflow by using 'serviceCredentialsFileContent' instead of 'serviceCredentialsFile' to pass the Firebase service account JSON.