### PR TITLE
test(ci): Add manual workflow for Android CLI distribution

### DIFF
--- a/.github/workflows/test-android-cli.yml
+++ b/.github/workflows/test-android-cli.yml
@@ -1,0 +1,42 @@
+name: Test Android Distribution via direct CLI
+
+on:
+  workflow_dispatch: # Allows manual triggering
+
+jobs:
+  test_direct_distribution:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: 'stable'
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Build APK
+        run: flutter build apk --release
+
+      - name: Distribute to Firebase using CLI
+        run: |
+          # Install Firebase CLI
+          npm install -g firebase-tools
+
+          # Distribute using the command
+          firebase appdistribution:distribute build/app/outputs/flutter-apk/app-release.apk \
+            --app "${{ secrets.FIREBASE_ANDROID_APP_ID }}" \
+            --groups "testers-preproduccion" \
+            --release-notes "Test release from direct CLI command" \
+            --token "${{ secrets.FIREBASE_TOKEN }}"
+        env:
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_CLI_TOKEN }}


### PR DESCRIPTION
This PR adds a manually triggered workflow to test the distribution of Android APKs using the Firebase CLI directly, as per the official documentation. This is for verification purposes.